### PR TITLE
Small tweaks

### DIFF
--- a/api/models/llama/llama.py
+++ b/api/models/llama/llama.py
@@ -76,7 +76,7 @@ class Llama(LlamaInput):
     A llama, with details of it's name, color, status, current score, current coordinates and its steps list.
     """
 
-    llama_id: int = Field(description="The llamas name.")
+    llama_id: int = Field(description="The llamas Id.")
     score: int = Field(default=0, description="Current score of the llama.")
     start_coordinates: List[int] = Field(
         default=[0, 0],

--- a/api/routers/llama.py
+++ b/api/routers/llama.py
@@ -76,7 +76,7 @@ async def create_lama(llama: LlamaInput = Body(description="Something")) -> Llam
     operation_id="get_llama_by_id",
 )
 async def get_llama(
-    llama_id: int = Path(description="A llama's id", example=123)
+    llama_id: int = Path(description="A llama's id", examples=[123])
 ) -> Llama:
     """
     Get llama by an id
@@ -96,11 +96,11 @@ async def get_llama(
     operation_id="add_steps",
 )
 async def add_steps(
-    llama_id: int = Path(description="A llama's id", example=123),
+    llama_id: int = Path(description="A llama's id", examples=[123]),
     direction: Direction = Query(
         description="The direction you want the llama to move"
     ),
-    steps: int = Query(description="The number of steps to make", example=3),
+    steps: int = Query(description="The number of steps to make", examples=[3]),
 ) -> StepResult:
     """
     Move a llama up, down, left or right by a positive number of steps.
@@ -138,7 +138,7 @@ async def add_steps(
     operation_id="move_llama",
 )
 async def move_llama(
-    llama_id: int = Path(description="A llama's id", example=123)
+    llama_id: int = Path(description="A llama's id", examples=[123])
 ) -> MoveResult:
     """
     Move the llama following the step instructions previously added.

--- a/api/routers/llama.py
+++ b/api/routers/llama.py
@@ -165,7 +165,7 @@ async def move_llama(
             break
 
     llama.steps_list = new_steps_list
-    await manager.broadcast(json.dumps({"event": "move", "data": llama.dict()}))
+    await manager.broadcast(json.dumps({"event": "move", "data": llama.model_dump()}))
     return {
         "llama_id": llama_id,
         "score": llama.score,


### PR DESCRIPTION
A set of small tweaks:

- correcting the llama id documentation
- using `examples` instead of `example` for parameter examples
- removing a call to a deprecated method